### PR TITLE
Set jekyll version to current 2.x version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,13 +57,13 @@ export GEM_HOME=$BUILD_DIR/.gems
 export PATH=$BUILD_DIR/.gems/bin:$PATH
 
 if [ ! -f $BUILD_DIR/.gems/bin/jekyll ]; then
-    echo "Jekyll not found!"
-    echo "-----> Installing Jekyll"
-    gem install liquid -v 2.2.2 --no-rdoc --no-ri | indent
-    gem install jekyll redcarpet sass --no-rdoc --no-ri | indent
-    gem install bundler --no-rdoc --no-ri | indent
-    gem install therubyracer --no-rdoc --no-ri | indent
-
+  echo "Jekyll not found!"
+  echo "-----> Installing Jekyll"
+  gem install liquid -v 2.2.2 --no-rdoc --no-ri | indent
+  gem install jekyll -v 2.5.3 --no-rdoc --no-ri | indent
+  gem install redcarpet sass --no-rdoc --no-ri | indent
+  gem install bundler --no-rdoc --no-ri | indent
+  gem install therubyracer --no-rdoc --no-ri | indent
 fi
 
 echo "-----> Building Jekyll site"

--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ fi
 
 echo "-----> Building Jekyll site"
 cd $BUILD_DIR
-$BUILD_DIR/.gems/bin/bundle install | indent
+$BUILD_DIR/.gems/bin/bundle install --binstubs=$BUILD_DIR/.gems/bin --path=$BUILD_DIR/.gems | indent
 $BUILD_DIR/.gems/bin/jekyll build | indent
 if [ -f sass/style.scss ] ; then
   $BUILD_DIR/.gems/bin/sass sass/style.scss style.css | indent


### PR DESCRIPTION
Otherwise the current version (>= 3.0) is installed and this doesn't support Ruby < 2.0 any more causing the buildpack to fail on push to Dokku.
Ideally the Ruby version should be upgraded to 2.x so we can use Jekyll 3.x but I don't know enough about buildpacks to do this.

I also set it so bundler installs the gems in a local folder. I had some issues with Jekyll not finding gemfiles for plugins.
